### PR TITLE
Track & store changes to the board in the course of a turn

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,48 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: Test
+    runs-on: ${{matrix.os}}
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      matrix:
+        include:
+          - build: linux
+            os: ubuntu-latest
+            rust: beta
+            target: x86_64-unknown-linux-musl
+            cross: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ~/.rustup
+            target
+          key: ${{ runner.os }}-${{ matrix.rust }}
+
+      - name: Install Rust
+        run: |
+          rustup install ${{ matrix.rust }}
+
+      - name: Test
+        run: cargo test

--- a/src/game.rs
+++ b/src/game.rs
@@ -1,13 +1,14 @@
-use super::board::Board;
+use super::board::{Board, Coordinate, Square};
 use super::hand::Hands;
 use super::judge::Judge;
-use super::moves::Move;
+use super::moves::{Change, Move};
 
 #[derive(Default)]
 pub struct Game {
     pub board: Board, // TODO: should these actually be public?
     pub hands: Hands,
     pub judge: Judge,
+    pub recent_changes: Vec<Change>,
     next_player: usize,
     winner: Option<usize>,
 }
@@ -18,6 +19,7 @@ impl Game {
             board: Board::new(width, height),
             hands: Hands::default(),
             judge: Judge::default(),
+            recent_changes: vec![],
             next_player: 0,
             winner: None,
         }
@@ -36,13 +38,16 @@ impl Game {
             return Err("Only the next player can play");
         }
 
-        if let Err(msg) = self
+        self.recent_changes = match self
             .board
             .make_move(next_move, &mut self.hands, &self.judge)
         {
-            println!("{}", msg);
-            return Err("Couldn't make move"); // TODO: propogate error post polonius
-        }
+            Ok(changes) => changes,
+            Err(msg) => {
+                println!("{}", msg);
+                return Err("Couldn't make move"); // TODO: propogate error post polonius
+            }
+        };
 
         if let Some(winner) = Judge::winner(&(self.board)) {
             self.winner = Some(winner);


### PR DESCRIPTION
A precursor to adding UI or networking is the ability to display the outcome of a turn, rather than it all happening instantly (i.e. it's useful to see what lost and what was truncated)

This PR makes the board-action functions return a `ChangeDetail` for their modification, and higher level methods return a `Change` for the action that was taken.